### PR TITLE
Added support for CDH6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,3 +61,7 @@ jobs:
     - name: CDH 5.15
       jdk: openjdk8
       script: mvn clean install -PCDH-5.15
+
+    - name: CDH 6.3
+      jdk: openjdk8
+      script: mvn clean install -PCDH-6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Code improvements
 * Do not implicitly set SPARK_MASTER in configuration
+* Added support for CDH6
 
 
 # Version 0.13.0 - 2020-04-21

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -26,6 +26,12 @@
                 <docker.base-image.version>2.3.3</docker.base-image.version>
             </properties>
         </profile>
+        <profile>
+            <id>CDH-6.3</id>
+            <properties>
+                <docker.base-image.version>2.4.5</docker.base-image.version>
+            </properties>
+        </profile>
     </profiles>
 
     <build>

--- a/flowman-plugins/impala/pom.xml
+++ b/flowman-plugins/impala/pom.xml
@@ -17,7 +17,7 @@
         <plugin.name>flowman-impala</plugin.name>
         <plugin.version>${project.version}</plugin.version>
         <plugin.jar>${project.build.finalName}.jar</plugin.jar>
-        <impala.jdbc.version>2.5.42</impala.jdbc.version>
+        <impala.jdbc.version>2.6.17.1020</impala.jdbc.version>
     </properties>
 
     <repositories>
@@ -130,8 +130,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.cloudera</groupId>
-            <artifactId>ImpalaJDBC41</artifactId>
+            <groupId>Impala</groupId>
+            <artifactId>ImpalaJDBC42</artifactId>
             <version>${impala.jdbc.version}</version>
         </dependency>
 

--- a/flowman-plugins/impala/pom.xml
+++ b/flowman-plugins/impala/pom.xml
@@ -25,6 +25,10 @@
             <id>odysseus</id>
             <url>http://repo.odysseusinc.com/artifactory/community-libs-release-local/</url>
         </repository>
+        <repository>
+            <id>cloudera-ext</id>
+            <url>https://repository.cloudera.com/artifactory/ext-release-local/</url>
+        </repository>
     </repositories>
 
     <build>

--- a/flowman-plugins/impala/pom.xml
+++ b/flowman-plugins/impala/pom.xml
@@ -22,10 +22,6 @@
 
     <repositories>
         <repository>
-            <id>odysseus</id>
-            <url>http://repo.odysseusinc.com/artifactory/community-libs-release-local/</url>
-        </repository>
-        <repository>
             <id>cloudera-ext</id>
             <url>https://repository.cloudera.com/artifactory/ext-release-local/</url>
         </repository>

--- a/flowman-plugins/impala/src/main/resources/plugin.yml
+++ b/flowman-plugins/impala/src/main/resources/plugin.yml
@@ -4,5 +4,5 @@ version: ${plugin.version}
 isolation: false
 jars:
   - ${plugin.jar}
-  - ImpalaJDBC41-${impala.jdbc.version}.jar
+  - ImpalaJDBC42-${impala.jdbc.version}.jar
   - hive-service-${hive.version}.jar

--- a/flowman-plugins/impala/src/main/scala/com/dimajix/flowman/catalog/ImpalaExternalCatalog.scala
+++ b/flowman-plugins/impala/src/main/scala/com/dimajix/flowman/catalog/ImpalaExternalCatalog.scala
@@ -31,7 +31,7 @@ import com.dimajix.flowman.jdbc.HiveDialect
 
 
 object ImpalaExternalCatalog {
-    val IMPALA_DEFAULT_DRIVER = "com.cloudera.impala.jdbc41.Driver"
+    val IMPALA_DEFAULT_DRIVER = "com.cloudera.impala.jdbc.Driver"
     val IMPALA_DEFAULT_PORT = 21050
 
     case class Connection(

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,49 @@
             </dependencyManagement>
         </profile>
 
+        <profile>
+            <id>cdh6.3.3</id>
+            <repositories>
+                <repository>
+                    <id>cloudera</id>
+                    <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+                </repository>
+            </repositories>
+            <properties>
+                <cdh.version>cdh6.3.3</cdh.version>
+                <spark.version>2.4.0-cdh6.3.3</spark.version>
+                <spark-hive.scope>provided</spark-hive.scope>
+                <spark-api.version>2.4</spark-api.version>
+                <hadoop.version>3.0.0-${cdh.version}</hadoop.version>
+                <hadoop-api.version>3.0</hadoop-api.version>
+                <hive.version>2.1.1-${cdh.version}</hive.version>
+                <hbase.version>2.1.0-${cdh.version}</hbase.version>
+                <kafka.version>0.10.0-kafka-2.1.0</kafka.version>
+                <avro.version>1.8.2-${cdh.version}</avro.version>
+                <guava.version>14.0.1</guava.version>
+                <json4s.version>3.5.3</json4s.version>
+                <netty-all.version>4.1.42.Final</netty-all.version>
+                <jackson.version>2.9.10</jackson.version>
+                <jackson.databind.version>2.9.10.1</jackson.databind.version>
+                <commons-lang.version>2.6</commons-lang.version>
+                <commons-lang3.version>3.7</commons-lang3.version>
+                <commons-math3.version>3.4.1</commons-math3.version>
+                <commons-collections.version>3.2.1</commons-collections.version>
+                <slf4j.version>1.7.25</slf4j.version>
+                <scala.version>2.11.12</scala.version>
+                <scala.api_version>2.11</scala.api_version>
+            </properties>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.mortbay.jetty</groupId>
+                        <artifactId>jetty-sslengine</artifactId>
+                        <version>6.1.26.cloudera.4</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+        </profile>
+
         <!-- Then come the individual package profiles, which can override distribution settings -->
         <profile>
             <id>spark-2.3</id>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         </profile>
 
         <profile>
-            <id>cdh6.3.3</id>
+            <id>CDH-6.3</id>
             <repositories>
                 <repository>
                     <id>cloudera</id>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,10 @@
                     <id>cloudera</id>
                     <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
                 </repository>
+                <repository>
+                    <id>cloudera-ext</id>
+                    <url>https://repository.cloudera.com/artifactory/ext-release-local/</url>
+                </repository>
             </repositories>
             <properties>
                 <cdh.version>cdh6.3.3</cdh.version>

--- a/pom.xml
+++ b/pom.xml
@@ -168,10 +168,6 @@
                     <id>cloudera</id>
                     <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
                 </repository>
-                <repository>
-                    <id>cloudera-ext</id>
-                    <url>https://repository.cloudera.com/artifactory/ext-release-local/</url>
-                </repository>
             </repositories>
             <properties>
                 <cdh.version>cdh6.3.3</cdh.version>
@@ -182,7 +178,7 @@
                 <hadoop-api.version>3.0</hadoop-api.version>
                 <hive.version>2.1.1-${cdh.version}</hive.version>
                 <hbase.version>2.1.0-${cdh.version}</hbase.version>
-                <kafka.version>0.10.0-kafka-2.1.0</kafka.version>
+                <kafka.version>2.2.1-${cdh.version}</kafka.version>
                 <avro.version>1.8.2-${cdh.version}</avro.version>
                 <guava.version>14.0.1</guava.version>
                 <json4s.version>3.5.3</json4s.version>


### PR DESCRIPTION
The previous ImpalaJDBC41 driver would not work on CDH6 anymore. I used the newest ImpalaJDBC42 which was available. I assume it has full backward compatibility.