### PR TITLE
#496 updated Maven profile for CDP 7.1.9 build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.30.2 - 2024-07-29
+
+* github-496: updated build profile for CDP 7.1.9 platform version
+
 # Version 0.30.1 - 2023-04-12
 
 * github-379: [BUG] Parallel execution of multiple targets runs too many targets on Java 17

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
             </dependencyManagement>
         </profile>
         <profile>
-            <id>CDP-7.1</id>
+            <id>CDP-7.1.9-SP1</id>
             <repositories>
                 <repository>
                     <id>cloudera</id>
@@ -249,7 +249,7 @@
             </repositories>
             <properties>
                 <hadoop.dist>cdp7</hadoop.dist>
-                <cdp.version>7.1.8.0-801</cdp.version>
+                <cdp.version>7.1.9.1000-103</cdp.version>
                 <java.version>1.8</java.version>
                 <scala.version>2.11.12</scala.version>
                 <scala.api_version>2.11</scala.api_version>
@@ -263,11 +263,11 @@
                 <hadoop-api.version>3.1</hadoop-api.version>
                 <hive.version>3.1.3000.${cdp.version}</hive.version>
                 <hive-storage-api.version>3.1.3000.${cdp.version}</hive-storage-api.version>
-                <hbase.version>2.4.6.${cdp.version}</hbase.version>
-                <kafka.version>2.4.1.7.1.5.0-257</kafka.version>
+                <hbase.version>2.4.17.${cdp.version}</hbase.version>
+                <kafka.version>3.4.1.${cdp.version}</kafka.version>
                 <derby.version>10.14.2.0</derby.version>
-                <zookeeper.version>3.5.5.${cdp.version}</zookeeper.version>
-                <avro.version>1.8.2.${cdp.version}</avro.version>
+                <zookeeper.version>3.8.1.${cdp.version}</zookeeper.version>
+                <avro.version>1.11.1.${cdp.version}</avro.version>
                 <json4s.version>3.5.3</json4s.version>
                 <json-smart.version>2.3</json-smart.version>
                 <guava.version>28.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
             </dependencyManagement>
         </profile>
         <profile>
-            <id>CDP-7.1.9-SP1</id>
+            <id>CDP-7.1</id>
             <repositories>
                 <repository>
                     <id>cloudera</id>


### PR DESCRIPTION
@kupferk I thought it would be good to rename the profile to make sure that whoever rebuilds the project will for sure be aware that the builds targets the new Cloudera minor release.

I used the following version numbers as reference:
https://docs.cloudera.com/cdp-private-cloud-base/7.1.9/runtime-release-notes/topics/rt-pvc-runtime-component-versions-719sp1.html